### PR TITLE
Update nI2C.cpp

### DIFF
--- a/nI2C.cpp
+++ b/nI2C.cpp
@@ -342,7 +342,7 @@ void CI2C::ReadCallback(const CTWI::status_t status)
 
 CI2C::status_t CI2C::WaitForComplete(void)
 {
-    unsigned long end = millis() + (unsigned long)m_timeout;
+    unsigned long endBase = millis();
 
     // Wait while transmission incomplete
     while (!g_rx_complete)
@@ -351,7 +351,7 @@ CI2C::status_t CI2C::WaitForComplete(void)
         if (m_timeout > 0)
         {
             // Check current time
-            if (millis() > end)
+            if ( millis() - endBasse  >= (unsigned long)m_timeout)
             {
                 return STATUS_TIMEOUT; // Timeout
             }


### PR DESCRIPTION
Comparing difference between millis() and a previous millis() by subtracting one from the other even works if it has overflowed in between.
Results will be unpredictable. Either timeout not being respected or it never being reached( when end results in something close to 0xFFFFFFFF and millis having rolled over in the meantime.